### PR TITLE
add mutex for finger list / use dereferenced interface

### DIFF
--- a/src/chord/ring/chord.go
+++ b/src/chord/ring/chord.go
@@ -73,7 +73,7 @@ func(ch *Chord) CheckPredecessor() {
 }
 
 // PrecedingNode searches the local table for the highest predecessor of id
-func(ch *Chord) PrecedingNode(id uint64) *Node {
+func(ch *Chord) PrecedingNode(id uint64) Node {
 	panic("todo")
 }
 


### PR DESCRIPTION
Hi Team,

I changed the template a bit, can you confirm these changes can be applied to your current version?
+ add a mutex for finger list and the getter/setter function because the finger list will be updated concurrently by different goroutines (like periodical call of `FixFingers` and `Stabilize`).
+ change the finger list from `[]*Node` to `[]Node` because it's more common to use the interface variables rather than pointers to interfaces